### PR TITLE
Change `open` strings to raw strings

### DIFF
--- a/convert_to_xkb.py
+++ b/convert_to_xkb.py
@@ -58,8 +58,8 @@ KPDL DECIMAL"""
 
 
 
-output = open("US - international - custom - nodeadkeys - greek.xkb","w")
-input = open("US - international - custom - nodeadkeys - greek.klc", encoding="utf-16")
+output = open(r"US - international - custom - nodeadkeys - greek.xkb","w")
+input = open(r"US - international - custom - nodeadkeys - greek.klc", encoding="utf-16")
 
 keycodes_linux = []
 keycodes_win = []


### PR DESCRIPTION
Absolute Paths have caused me some Problems, because I forgot to escape the backslashes (I'm not all that familiar with python), this can be avoided at no cost by using raw strings.